### PR TITLE
feat(): add review-app support for branches

### DIFF
--- a/lib/heroku/stage.rb
+++ b/lib/heroku/stage.rb
@@ -20,12 +20,22 @@ module Heroku
     private
 
     def heroku_pipeline_stage
-      return ENV.fetch('HEROKU_APP_NAME')[/pr-(\d*)/] if review_app?
+      return branch || pull_request if review_app?
 
       dev_or_test = Rails.env.development? || Rails.env.test?
       dev_or_test ? '' : ENV.fetch('HEROKU_APP_NAME')[/staging|production/]
     rescue KeyError
       raise $!, enable_dyno_metadata_message($!), $!.backtrace
+    end
+
+    def branch
+      app_name = ENV.fetch('HEROKU_APP_NAME')
+
+      return "br-#{app_name.split('-br-')[1]}" if app_name.include? '-br-'
+    end
+
+    def pull_request
+      ENV.fetch('HEROKU_APP_NAME')[/pr-(\d*)/]
     end
 
     def enable_dyno_metadata_message(exception)

--- a/spec/heroku-stage_spec.rb
+++ b/spec/heroku-stage_spec.rb
@@ -66,18 +66,34 @@ On the next deploy the key will be populated with the app name
   end
 
   describe 'on review app' do
-    before(:each) do
-      allow(ENV).to receive(:[]).with("HEROKU_PARENT_APP_NAME").and_return("myapp-staging")
-      allow(ENV).to receive(:fetch).with('HEROKU_APP_NAME').and_return('myapp-staging-pr-766')
-    end
-
-    it 'get the correct stage' do
-      expect(Heroku.stage).to eq('pr-766')
-    end
 
     describe '#review_app?' do
       it 'returns true' do
         expect(Heroku.review_app?).to be(true)
+      end
+    end
+
+    describe '#heroku_pipeline_stage' do
+      context 'when app is created from pull request' do
+        before(:each) do
+          allow(ENV).to receive(:[]).with("HEROKU_PARENT_APP_NAME").and_return("myapp-staging")
+          allow(ENV).to receive(:fetch).with('HEROKU_APP_NAME').and_return('myapp-staging-pr-766')
+        end
+
+        it 'get the correct stage' do
+          expect(Heroku.stage).to eq('pr-766')
+        end
+      end
+      
+      context 'when app is created from branch' do
+        before(:each) do
+          allow(ENV).to receive(:[]).with("HEROKU_PARENT_APP_NAME").and_return("myapp-staging")
+          allow(ENV).to receive(:fetch).with('HEROKU_APP_NAME').and_return('myapp-staging-br-new-feature')
+        end
+
+        it 'get the correct stage' do
+          expect(Heroku.stage).to eq('br-new-feature')
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

sometimes it may be useful to deploy a review app from a branch, but current regex only supports pull request based apps since it uses the regex `/pr-(\d*)/`

## Changes

Add support for branch based app names